### PR TITLE
Adds a regex config option for warp names

### DIFF
--- a/src/main/java/me/ford/iwarp/Settings.java
+++ b/src/main/java/me/ford/iwarp/Settings.java
@@ -120,6 +120,11 @@ public class Settings {
 		return getMessage("name-cannot-have-period",
 				"&cThe name of the warp &6{name}&c cointains a period (&7.&c) which is not allowed").replace("{name}", name);
 	}
+
+	public String getNameDoesntMatchPatternMessage(String name) {
+		return getMessage("name-doesnt-match-pattern",
+				"&cThe name of the warp &6{name}&c is forbidden. If this keeps happening, seek assistance from an admin.").replace("{name}", name);
+	}
 	
 	public String getNotEnoughMoneyMessage(double price) {
 		String msg = getMessage("not-enough-money", "&cYou do not have enough money: &4{amount}");

--- a/src/main/java/me/ford/iwarp/Settings.java
+++ b/src/main/java/me/ford/iwarp/Settings.java
@@ -44,7 +44,7 @@ public class Settings {
 	public double getMoveCost() {
 		return IW.getConfig().getDouble("movecost", 0);
 	}
-	
+
 	public double getRenameCost() {
 		return IW.getConfig().getDouble("renamecost", 0);
 	}
@@ -71,6 +71,10 @@ public class Settings {
 
 	public boolean useBstats() {
 		return IW.getConfig().getBoolean("use-bstats", true);
+	}
+
+	public String getWarpNameFormat() {
+		return IW.getConfig().getString("warp-name-format", "^.{1,15}$");
 	}
 	
 	// addons

--- a/src/main/java/me/ford/iwarp/commands/subcommands/CreateCommand.java
+++ b/src/main/java/me/ford/iwarp/commands/subcommands/CreateCommand.java
@@ -77,6 +77,11 @@ public class CreateCommand extends AbstractSubCommand {
 			return true;
 		}
 
+		if (!warpName.matches(IW.getSettings().getWarpNameFormat())) {
+			sender.sendMessage(IW.getSettings().getNameContainsPeriodMessage(warpName));
+			return true;
+		}
+
 		// helpers
 		final WarpHandler wh = IW.getWarpHandler();
 		final Settings settings = IW.getSettings();

--- a/src/main/java/me/ford/iwarp/commands/subcommands/CreateCommand.java
+++ b/src/main/java/me/ford/iwarp/commands/subcommands/CreateCommand.java
@@ -2,7 +2,9 @@ package me.ford.iwarp.commands.subcommands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.ConversationContext;
@@ -77,9 +79,13 @@ public class CreateCommand extends AbstractSubCommand {
 			return true;
 		}
 
-		if (!warpName.matches(IW.getSettings().getWarpNameFormat())) {
-			sender.sendMessage(IW.getSettings().getNameContainsPeriodMessage(warpName));
-			return true;
+		try {
+			if (!warpName.matches(IW.getSettings().getWarpNameFormat())) {
+				sender.sendMessage(IW.getSettings().getNameDoesntMatchPatternMessage(warpName));
+				return true;
+			}
+		} catch (PatternSyntaxException exception) {
+			Bukkit.getLogger().warning("You have an error in the warp-name-format configuration setting. Until this error is fixed, iwarp will allow any warp name. You can reset it to \"^.{1,15}$\".");
 		}
 
 		// helpers

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,11 @@ include-essentials-warps-in-list: false
 use-bstats: true
 
 commands-on-warp-expire: []
+
+# this specifies a regular expression (regex) for what's allowed in a warp name
+# you can read about regex, e.g in: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+# chatgpt is also pretty good at coming up with regex if you already have a basic understanding.
+# If you do not know what you're doing, it's probably best to leave this value alone.
 warp-name-format: "^.{1,15}$"
 
 confirm:
@@ -38,7 +43,8 @@ messages:
   not-your-warp: "&cThis warp does not belong to you: &7{name}"
   renewed-warp: "&7You've successfully renewed the warp &6{name}&7 for another &8{days}&7 days for $&8{amount}&7 (&6{total}&7 days left in total)"
   name-not-int: "&cWarp names cannot be integers!"
-  name-cannot-have-period: "&cThe name of the warp &6{name}&c cointains a period (&7.&c) which is not allowed"
+  name-cannot-have-period: "&cThe name of the warp &6{name}&c contains a period (&7.&c) which is not allowed"
+  name-doesnt-match-pattern: "&cThe name of the warp &6{name}&c is forbidden. If this keeps happening, seek assistance from an admin."
   issue-while-creating-warp: "&cThere was an unexpected issue while creating warp: &4{name}"
   inssufficient-permissions: "&cYou do not have permission to use this command!"
   moved-warp: "&7You've successfully moved the warp &6{name}&7 to your current location for &8{amount}"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,7 +10,7 @@ include-essentials-warps-in-list: false
 use-bstats: true
 
 commands-on-warp-expire: []
-
+warp-name-format: "^.{1,15}$"
 confirm:
   create: false
   move: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ use-bstats: true
 
 commands-on-warp-expire: []
 warp-name-format: "^.{1,15}$"
+
 confirm:
   create: false
   move: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ${project.name}
 version: ${project.version}
-author: Ford DrBot
+author: Ford
 main: ${project.groupId}.${project.artifactId}.IWarpPlugin
 api-version: 1.13
 depend: [Essentials, Vault]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ${project.name}
 version: ${project.version}
-author: Ford
+author: Ford DrBot
 main: ${project.groupId}.${project.artifactId}.IWarpPlugin
 api-version: 1.13
 depend: [Essentials, Vault]


### PR DESCRIPTION
This will still always enforce the rule about not allowing periods.
I wasn't sure how to deal with the message to give the user when their warp name doesn't pass the regex. Let me know what you think. I'm thinking either

1. We could make a second message something like "This warp name isn't allowed" for when the regex isn't passed. It might be a little weird when the message they get for using a period is so specific but the message they get for making their warp name too long is so vague. 
2. We could use the same message about not allowing warps to have periods and expect that people change the name-cannot-have-period message to something less specific if they're going to add regex. This is what I did but one thing I don't like about it is that the config option is still called name-cannot-have-period. What do you think about me removing that config option and replacing it with name-format-invalid?